### PR TITLE
Remove parallel scheduler usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,7 @@ Project Reactor helps us do that with its concise, functional-programming style 
 ```
     public Mono<Map<String, Optional<Double>>> getPricing(List<String> pricingCountryCodes) {
         return Flux.fromIterable(pricingCountryCodes)
-            .parallel()
-            .runOn(Schedulers.parallel())
             .flatMap(pricingClient::getPricing)
-            .sequential()
             .collectMap(Pricing::getCountryCode, Pricing::getPrice)
             .doOnNext(this::removeEmptyValues);
     }

--- a/src/main/java/com/reactive/api/pricing/DefaultPricingService.java
+++ b/src/main/java/com/reactive/api/pricing/DefaultPricingService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 import java.util.Map;
@@ -17,10 +16,7 @@ public class DefaultPricingService implements PricingService {
 
     public Mono<Map<String, OptionalDouble>> getPricing(List<String> pricingCountryCodes) {
         return Flux.fromIterable(pricingCountryCodes)
-            .parallel()
-            .runOn(Schedulers.parallel())
             .flatMap(pricingClient::getPricing)
-            .sequential()
             .collectMap(Pricing::getCountryCode, Pricing::getPrice)
             .doOnNext(this::removeEmptyValues);
     }

--- a/src/main/java/com/reactive/api/shipment/DefaultShipmentService.java
+++ b/src/main/java/com/reactive/api/shipment/DefaultShipmentService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 import java.util.Map;
@@ -17,10 +16,7 @@ public class DefaultShipmentService implements ShipmentService {
 
     public Mono<Map<String, Optional<List<Product>>>> getShipment(List<String> shipmentsOrderNumbers) {
         return Flux.fromIterable(shipmentsOrderNumbers)
-            .parallel()
-            .runOn(Schedulers.parallel())
             .flatMap(shipmentClient::getShipment)
-            .sequential()
             .collectMap(Shipment::getOrderNumber, Shipment::getProducts)
             .doOnNext(this::removeEmptyValues);
     }

--- a/src/main/java/com/reactive/api/track/DefaultTrackService.java
+++ b/src/main/java/com/reactive/api/track/DefaultTrackService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 import java.util.Map;
@@ -17,10 +16,7 @@ public class DefaultTrackService implements TrackService {
 
     public Mono<Map<String, Optional<Status>>> getTrack(List<String> trackOrderNumbers) {
         return Flux.fromIterable(trackOrderNumbers)
-            .parallel()
-            .runOn(Schedulers.parallel())
             .flatMap(trackClient::getTrack)
-            .sequential()
             .collectMap(Track::getOrderNumber, Track::getStatus)
             .doOnNext(this::removeEmptyValues);
     }


### PR DESCRIPTION
## Summary
- simplify `DefaultPricingService` without using parallel scheduler
- simplify `DefaultShipmentService` without using parallel scheduler
- simplify `DefaultTrackService` without using parallel scheduler
- update README example

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840150f8bf8832bb54c7632edda3b53